### PR TITLE
Update broken links and use quarto-pub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,8 @@ jobs:
         uses: quarto-dev/quarto-actions/publish@v2
         with:
           render: false
-          target: gh-pages
+          target: quarto-pub
+          QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_TOKEN }}
 
   publish-docs-no-build:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# README[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit.png)](https://github.com/pre-commit/pre-commit)[![GitHub-Pages-Action](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml)[![quarto-ci-ghcr-publish](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/dev-container-publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/dev-container-publish.yml)
+# README[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit.png)](https://github.com/pre-commit/pre-commit)[![GitHub-Pages-Action](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml)[![Quarto-Render/Publish-Pages/Container](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/quarto-render-build.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/quarto-render-build.yml)
+
 
 <p> <a href="https://cameronrutherford.github.io/cameronrutherford/index.html" target="_blank" rel="noreferrer"> <img src="./config/qr-code.svg" width="50%"/> </a>
 &#10;
@@ -42,17 +43,13 @@ actions</a></li>
 <li><a
 href="https://cameronrutherford.github.io/cameronrutherford/config/quarto.html">quarto</a></li>
 </ul></td>
-<td><div>
-<p><a href="https://quarto.org/" style="float: left;" target="_blank"
-rel="noreferrer"><img src="https://quarto.org/quarto.png"
-width="160" /></a></p>
-</div>
-<div>
+<td><p><a href="https://quarto.org/" style="float: left;"
+target="_blank" rel="noreferrer"><img
+src="https://quarto.org/quarto.png" width="160" /></a></p>
 <p><a href="https://www.freepnglogos.com/images/javascript-39398.html"
 style="float: left;" target="_blank" rel="noreferrer"><img
 src="https://www.freepnglogos.com/uploads/javascript-png/fix-html-css-javascript-for-website-logo-6.png"
 width="160" /></a></p>
-</div>
 <p><a href="https://www.json.org/json-en.html" target="_blank"
 rel="noreferrer"><img
 src="https://www.vectorlogo.zone/logos/json/json-icon.svg"
@@ -66,12 +63,10 @@ height="40" /></a> <a href="https://github.com/" target="_blank"
 rel="noreferrer"><img
 src="https://www.vectorlogo.zone/logos/github/github-icon.svg"
 width="40" /></a></p>
-<div>
 <p><a href="https://www.latex-project.org/" style="float: left;"
 target="_blank" rel="noreferrer"><img
 src="https://upload.wikimedia.org/wikipedia/commons/4/45/LaTeX_project_logo_bird.svg"
-width="160" /></a></p>
-</div></td>
+width="160" /></a></p></td>
 </tr>
 <tr class="even">
 <td colspan="2"><p>This is an HTML table written in quarto, rendered

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # README[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit.png)](https://github.com/pre-commit/pre-commit)[![GitHub-Pages-Action](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml)[![Quarto-Render/Publish-Pages/Container](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/quarto-render-build.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/quarto-render-build.yml)
 
 
-<p> <a href="https://cameronrutherford.github.io/cameronrutherford/index.html" target="_blank" rel="noreferrer"> <img src="./config/qr-code.svg" width="50%"/> </a>
+<p> <a href="https://cameronrutherford.quarto.pub/camerons-git-site/" target="_blank" rel="noreferrer"> <img src="./config/qr-code.svg" width="50%"/> </a>
 &#10;
 <table data-quarto-postprocess="true">
 <colgroup>
@@ -19,10 +19,10 @@
 <td>CV / README:
 <ul>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/resume/resume.html">Resume
+href="https://cameronrutherford.quarto.pub/camerons-git-site//resume/resume.html">Resume
 / CV PDF Download</a></li>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/index.html">GitHub
+href="https://cameronrutherford.quarto.pub/camerons-git-site/">GitHub
 Pages Homepage</a></li>
 <li><a
 href="https://github.com/cameronrutherford/cameronrutherford">GitHub
@@ -31,17 +31,17 @@ repository</a></li>
 Documentation:
 <ul>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/config/quickstart.html">Quickstart</a></li>
+href="https://cameronrutherford.quarto.pub/camerons-git-site/config/quickstart.html">Quickstart</a></li>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/config/devcontainer.html">Docker
+href="https://cameronrutherford.quarto.pub/camerons-git-site/config/devcontainer.html">Docker
 / Devcontainer</a></li>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/config/pre-commit.html">pre-commit</a></li>
+href="https://cameronrutherford.quarto.pub/camerons-git-site/config/pre-commit.html">pre-commit</a></li>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/config/github-actions.html">github
+href="https://cameronrutherford.quarto.pub/camerons-git-site/config/github-actions.html">github
 actions</a></li>
 <li><a
-href="https://cameronrutherford.github.io/cameronrutherford/config/quarto.html">quarto</a></li>
+href="https://cameronrutherford.quarto.pub/camerons-git-site/config/quarto.html">quarto</a></li>
 </ul></td>
 <td><p><a href="https://quarto.org/" style="float: left;"
 target="_blank" rel="noreferrer"><img

--- a/_publish.yml
+++ b/_publish.yml
@@ -1,0 +1,4 @@
+- source: project
+  quarto-pub:
+    - id: bbcc35d3-a3ab-48d0-8fe6-67258eb18402
+      url: 'https://cameronrutherford.quarto.pub/camerons-git-site'

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "README[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)[![GitHub-Pages-Action](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml)[![quarto-ci-ghcr-publish](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/dev-container-publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/dev-container-publish.yml)"
+title: "README[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)[![GitHub-Pages-Action](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/publish.yml)[![Quarto-Render/Publish-Pages/Container](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/quarto-render-build.yml/badge.svg)](https://github.com/cameronrutherford/cameronrutherford/actions/workflows/quarto-render-build.yml)"
 format:
     html:
         default: true

--- a/index.qmd
+++ b/index.qmd
@@ -12,7 +12,7 @@ format:
 ---
 
 ```{=html}
-<p> <a href="https://cameronrutherford.github.io/cameronrutherford/index.html" target="_blank" rel="noreferrer"> <img src="./config/qr-code.svg" width="50%"/> </a>
+<p> <a href="https://cameronrutherford.quarto.pub/camerons-git-site/" target="_blank" rel="noreferrer"> <img src="./config/qr-code.svg" width="50%"/> </a>
 
 <table>
   <thead>
@@ -26,17 +26,17 @@ format:
       <td>
         CV / README:
         <ul>
-          <li><a href="https://cameronrutherford.github.io/cameronrutherford/resume/resume.html">Resume / CV PDF Download</a></li>
-          <li><a href="https://cameronrutherford.github.io/cameronrutherford/index.html">GitHub Pages Homepage</a></li>
+          <li><a href="https://cameronrutherford.quarto.pub/camerons-git-site//resume/resume.html">Resume / CV PDF Download</a></li>
+          <li><a href="https://cameronrutherford.quarto.pub/camerons-git-site/">GitHub Pages Homepage</a></li>
           <li><a href="https://github.com/cameronrutherford/cameronrutherford">GitHub repository</a></li>
         </ul>
         Documentation:
         <ul>
-          <li><a href="https://cameronrutherford.github.io/cameronrutherford/config/quickstart.html">Quickstart</a></li>
-          <li><a href="https://cameronrutherford.github.io/cameronrutherford/config/devcontainer.html">Docker / Devcontainer</a></li>
-          <li> <a href="https://cameronrutherford.github.io/cameronrutherford/config/pre-commit.html">pre-commit</a></li>
-          <li> <a href="https://cameronrutherford.github.io/cameronrutherford/config/github-actions.html">github actions</a></li>
-          <li> <a href="https://cameronrutherford.github.io/cameronrutherford/config/quarto.html">quarto</a></li>
+          <li><a href="https://cameronrutherford.quarto.pub/camerons-git-site/config/quickstart.html">Quickstart</a></li>
+          <li><a href="https://cameronrutherford.quarto.pub/camerons-git-site/config/devcontainer.html">Docker / Devcontainer</a></li>
+          <li> <a href="https://cameronrutherford.quarto.pub/camerons-git-site/config/pre-commit.html">pre-commit</a></li>
+          <li> <a href="https://cameronrutherford.quarto.pub/camerons-git-site/config/github-actions.html">github actions</a></li>
+          <li> <a href="https://cameronrutherford.quarto.pub/camerons-git-site/config/quarto.html">quarto</a></li>
         </ul>
       </td>
       <td>


### PR DESCRIPTION
There are a myraid of bugs with gh-pages at the moment, and so using a different deployment backend seems easier than bothering to debug the BS, so here we are.